### PR TITLE
Switch to pypi.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "3.6"
 before_script:
-  - "echo `curl -s https://pypi.python.org/pypi/tlds/json | jq -r .info.version || echo none` > /tmp/pkgver"
+  - "echo `curl -s https://pypi.org/pypi/tlds/json | jq -r .info.version || echo none` > /tmp/pkgver"
   - "curl -s http://data.iana.org/TLD/tlds-alpha-by-domain.txt | head -n 1 | grep -Po \"(?<=Version )[0-9]+\" > /tmp/dbver"
 script: echo current=`cat /tmp/pkgver` iana=`cat /tmp/dbver`
 deploy:


### PR DESCRIPTION
pypi.python.org is closing on 2018/04/30. This PR switch from pypi.python.org to pypi.org to check the latest version during build and ensure build will continue working after pypi.python.org is shutdown.