### PR TITLE
Create CI based update flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-  schedule:
-    - cron:  '10 5 * * *'
 
 jobs:
   publish:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,7 +2,7 @@ name: "Update"
 on:
   workflow_dispatch:
   schedule: 
-    - cron: "21 4 * * 0"
+    - cron: "21 4 * * *"
 jobs:
   update:
     runs-on: ubuntu-latest

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,14 @@
+name: "Update"
+on:
+  workflow_dispatch:
+  schedule: 
+    - cron: "21 4 * * 0"
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update top-level domains from iana
+        run: ./update.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.py
+++ b/build.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+import os.path
+import re
+import urllib.request
+
+# fetch latest tlds file from iana
+r = urllib.request.urlopen("https://data.iana.org/TLD/tlds-alpha-by-domain.txt")
+assert r.status == 200
+lines = r.read().decode("utf-8").split("\n")
+
+# parse version and write it out
+header = lines.pop(0)
+if match := re.match("^# Version (?P<version>[0-9]+).*$", header):
+    version = match.group("version")
+    with open("./version", "w") as fd:
+        fd.write(version)
+else:
+    raise RuntimeError("Failed to match version")
+
+# format tlds and write them out
+tlds = [line.lower() for line in lines if line and not line.startswith("#")]
+target_dir = os.path.abspath("./tlds")
+with open(os.path.join(target_dir, "_data.py"), "w") as fd:
+    fd.write("tld_set = set(%s)\n" % (tlds,))

--- a/setup.py
+++ b/setup.py
@@ -1,56 +1,26 @@
-import os
-import re
-import sys
-from distutils.command.build_py import build_py
+from setuptools import setup
 
-from setuptools import setup, find_packages
-
-if sys.version_info.major >= 3:
-    import urllib.request
-
-    r = urllib.request.urlopen('https://data.iana.org/TLD/tlds-alpha-by-domain.txt')
-    assert r.status == 200
-    data = r.read().decode('utf-8').split('\n')
-else:
-    import urllib
-    
-    r = urllib.urlopen('https://data.iana.org/TLD/tlds-alpha-by-domain.txt')
-    assert r.getcode() == 200
-    data = r.read().split('\n')
-    
-version = re.match('^# Version (?P<version>[0-9]+).*$', data[0]).group('version')
-tlds = [i.lower() for i in data[1:] if i and not i.startswith('#')]
+with open("./version") as fd:
+    version = fd.read().strip()
 
 
-class build_tld_py(build_py):
-    def run(self):
-        if not self.dry_run:
-            target_dir = os.path.join(self.build_lib, 'tlds')
-            self.mkpath(target_dir)
-
-            with open(os.path.join(target_dir, '_data.py'), 'w') as f:
-                f.write('tld_set = set(%s)\n' % (tlds, ))
-
-        build_py.run(self)
-
-
-setup(name='tlds',
-      version=version,
-      description='Automatically updated list of valid TLDs taken directly from IANA',
-      long_description=open('README.rst').read(),
-      classifiers=[
-          'Development Status :: 5 - Production/Stable',
-          'Programming Language :: Python',
-          'License :: OSI Approved :: MIT License',
-          'Topic :: Communications',
-      ],
-      keywords='tld',
-      author='Amir Szekely',
-      author_email='kichik@gmail.com',
-      url='https://github.com/kichik/tlds',
-      license='MIT',
-      packages=['tlds'],
-      cmdclass={'build_py': build_tld_py},
-      include_package_data=True,
-      zip_safe=True,
-      )
+setup(
+    name="tlds",
+    version=version,
+    description="Automatically updated list of valid TLDs taken directly from IANA",
+    long_description=open("README.rst").read(),
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Programming Language :: Python",
+        "License :: OSI Approved :: MIT License",
+        "Topic :: Communications",
+    ],
+    keywords="tld",
+    author="Amir Szekely",
+    author_email="kichik@gmail.com",
+    url="https://github.com/kichik/tlds",
+    license="MIT",
+    packages=["tlds"],
+    include_package_data=True,
+    zip_safe=True,
+)

--- a/tlds/_data.py
+++ b/tlds/_data.py
@@ -1,0 +1,1 @@
+tld_set = set()

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eux
+
+./build.py
+
+if [ -z "$(git diff --exit-code)" ]; then
+    echo "No changes to the output on this push; exiting."
+    exit 0
+fi
+
+find .
+
+export VERSION=$(cat version)
+
+export GIT_AUTHOR_NAME="Github update bot"
+export GIT_AUTHOR_EMAIL="git@github.com"
+export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
+export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
+
+git add tlds/_data.py version
+
+git commit -m "Update IANA top-level domains to $VERSION"
+git tag --annotate --message="Release $VERSION" $VERSION
+git push origin HEAD:master $VERSION


### PR DESCRIPTION
Moves the update of the IANA top-level data into a CI based workflow, to allow building this package in a sandboxed environment, where network access is not allowed.

Also creates tags for each new data version.

Tested on my own repository. Looks like this:
 https://github.com/mweinelt/python-tlds/commit/98b93edefd8b267be50a7226f0de6a86a8dd893b

Could be extended by publishing to pypi, but that's not within my expertise.